### PR TITLE
[Develop] Feature/5 add create step

### DIFF
--- a/plop/plopfile.js
+++ b/plop/plopfile.js
@@ -85,6 +85,14 @@ module.exports = (plop) => {
         },
       }, {
         type: 'input',
+        name: 'itemCreateEntryFields',
+        message: 'What fields should we ask GraphQL endpoint for the Create view (separatated by spaces, for example "id name title") ? (itemCreateEntryFields) ?',
+        validate: (value) => {
+          if ((/.+/).test(value)) { return true; }
+          return 'itemCreateEntryFields is required';
+        },
+      }, {
+        type: 'input',
         name: 'graphQLRootEntry',
         message: "Are you using viewer or me, as a root entry point ? if yes, write it's name, else leave this empty ...",
       },
@@ -125,6 +133,11 @@ module.exports = (plop) => {
         type: 'add',
         path: '../src/modules/{{moduleName}}/containers/Home.js',
         templateFile: 'templates/module_generator_master_details/sampleModule/containers/Home.js.hbr',
+        abortOnFail: true,
+      }, {
+        type: 'add',
+        path: '../src/modules/{{moduleName}}/containers/{{uiItemName}}CreatePage.js',
+        templateFile: 'templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr',
         abortOnFail: true,
       }, {
         type: 'add',

--- a/plop/templates/module_generator_master_details/sampleModule/containers/Home.js.hbr
+++ b/plop/templates/module_generator_master_details/sampleModule/containers/Home.js.hbr
@@ -1,13 +1,15 @@
 import React from 'react';
 import { translate, Trans } from 'react-i18next';
 import { Header, Container } from 'semantic-ui-react';
-import { Route } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 
 import {{uiItemName}}sListPage from './{{uiItemName}}sListPage';
 import {{uiItemName}}DetailsPage from './{{uiItemName}}DetailsPage';
+import {{uiItemName}}CreatePage from './{{uiItemName}}CreatePage';
 
 const ItemsListPage = () => {{uiItemName}}sListPage;
 const ItemDetailsPage = () => {{uiItemName}}DetailsPage;
+const ItemCreatePage = () => {{uiItemName}}CreatePage;
 
 const HomePage = () =>
   (
@@ -24,8 +26,11 @@ const HomePage = () =>
         <br />
         <br />
       </Container>
-      <Route path="/{{dashCase moduleShortUniqueName}}" exact component={ItemsListPage()} />
-      <Route path="/{{dashCase moduleShortUniqueName}}/:id" exact component={ItemDetailsPage()} />
+      <Switch>
+        <Route path="/{{dashCase moduleShortUniqueName}}" exact component={ItemsListPage()} />
+        <Route path="/{{dashCase moduleShortUniqueName}}/create" exact component={ItemCreatePage()} />
+        <Route path="/{{dashCase moduleShortUniqueName}}/:id" exact component={ItemDetailsPage()} />
+      </Switch>
     </React.Fragment>
   );
 

--- a/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
+++ b/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
@@ -23,7 +23,7 @@ const RelayFormFields = {
   fields: [],
 };
 
-class  {{uiItemName}}CreatePage extends Component {
+class {{uiItemName}}CreatePage extends Component {
   state = {
     panelError: null,
     isLoading: false,
@@ -71,5 +71,4 @@ class  {{uiItemName}}CreatePage extends Component {
   }
 }
 
-
-export default  {{uiItemName}}CreatePage;
+export default {{uiItemName}}CreatePage;

--- a/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
+++ b/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import { Container } from 'semantic-ui-react';
+import { graphql } from 'react-relay';
+
+import RelayForm from '~/modules/coreUI/components/forms/RelayForm';
+import { XXXXLargeSpacer, LargeSpacer } from '~/modules/coreUI/components/layouts/helpers/Spacers';
+import { ErrorLabel } from '~/modules/coreUI/components/basic/Labels';
+import { BasicButton } from '~/modules/coreUI/components/basic/Button';
+
+const FormMutation = graphql`
+  mutation {{uiItemName}}CreatePageMutation (
+   $data : {{uiItemName}}CreateInput!
+  ) {
+    create{{uiItemName}}(
+     data : $data
+    ) {
+        {{itemCreateEntryFields}}
+    }
+  }
+`;
+
+const RelayFormFields = {
+  fields: [],
+};
+
+class  {{uiItemName}}CreatePage extends Component {
+  state = {
+    panelError: null,
+    isLoading: false,
+  };
+
+  onSuccess = () => {
+
+  }
+
+  onError = (error) => {
+    this.setState({ panelError: error });
+  };
+
+  setLoadingState = (isLoading) => {
+    this.setState({ isLoading });
+  }
+
+  submitForm = () => {
+    this.form.submitForm();
+  }
+
+  render() {
+    const { isLoading, panelError } = this.state;
+    return (
+      <Container>
+        <ErrorLabel>
+          {panelError}
+        </ErrorLabel>
+        <LargeSpacer />
+        <RelayForm
+          onRef={(ref) => { this.form = ref; }}
+          onFormError={error => this.onError(error)}
+          onFormSuccess={response => this.onSuccess(response)}
+          onFormLoading={loading => this.setLoadingState(loading)}
+          mutationRoot="create{{uiItemName}}"
+          options={RelayFormFields}
+          mutation={FormMutation}
+        />
+        <BasicButton width="100px" primary disabled={isLoading} onClicked={() => this.submitForm()}>
+          Create
+        </BasicButton>
+        <XXXXLargeSpacer />
+      </Container>
+    );
+  }
+}
+
+
+export default  {{uiItemName}}CreatePage;

--- a/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
+++ b/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr
@@ -9,13 +9,13 @@ import { BasicButton } from '~/modules/coreUI/components/basic/Button';
 
 const FormMutation = graphql`
   mutation {{uiItemName}}CreatePageMutation (
-   $data : {{uiItemName}}CreateInput!
+    $data : {{uiItemName}}CreateInput!
   ) {
-    create{{uiItemName}}(
-     data : $data
-    ) {
-        {{itemCreateEntryFields}}
-    }
+      create{{uiItemName}} (
+        data : $data
+      ) {
+          {{itemCreateEntryFields}}
+      }
   }
 `;
 

--- a/plop/templates/module_generator_master_details/sampleModule/containers/ItemsList.js.hbr
+++ b/plop/templates/module_generator_master_details/sampleModule/containers/ItemsList.js.hbr
@@ -5,18 +5,24 @@ import {
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Container, Segment } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
 
 import {{uiItemName}}sListEntry from './{{uiItemName}}sListEntry';
 
 const {{uiItemName}}sList = ({ query }) => (
   <Container >
     <Segment >
+      <Link
+        to="/{{dashCase moduleShortUniqueName}}/create"
+      >
+        Create {{uiItemName}}
+      </Link>
       {
         query ?
           query.{{graphQLMainQueryName}}.map(entry => (
             // eslint-disable-next-line no-underscore-dangle
             <Segment key={entry.__id} >
-              <PostsListEntry postInfo={entry} />
+              <{{uiItemName}}sListEntry {{camelCase uiItemName}}Info={entry} />
             </Segment>
           ))
         :

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -4,6 +4,10 @@
     "rules": {
         "react/jsx-filename-extension": [1, {
             "extensions": [".js", ".jsx"]
+        }],
+        "jsx-a11y/anchor-is-valid": [ "error", {
+            "components": [ "Link" ],
+            "specialLink": [ "to" ]
         }]
     },
     "env": {

--- a/src/modules/coreUI/components/forms/RelayForm.jsx
+++ b/src/modules/coreUI/components/forms/RelayForm.jsx
@@ -80,6 +80,19 @@ class RelayForm extends Component {
 
   getValue = () => this.Form.getValue();
 
+  getCommitFormMutationVariables = () => {
+    if (this.props.getCommitFormMutationVariables) {
+      return this.props.getCommitFormMutationVariables(this.Form);
+    }
+
+    const addiontalMutationVariables = this.props.addiontalMutationVariables || {};
+
+    return {
+      ...this.Form.getValue(),
+      ...addiontalMutationVariables,
+    };
+  };
+
   updateTcompOptionsWithErrors(fieldsErrors) {
     const { options } = this.props;
     const fields = {};
@@ -196,12 +209,7 @@ class RelayForm extends Component {
       return;
     }
 
-    const addiontalMutationVariables = this.props.addiontalMutationVariables || {};
-
-    const variables = {
-      ...formValues,
-      ...addiontalMutationVariables,
-    };
+    const variables = this.getCommitFormMutationVariables();
 
     this.onLoading(true);
 


### PR DESCRIPTION
this **PR** resolves part of issue #7 .

what has been **done** so far :

- Ability to generate **ItemCreatePage** using **RelayForm** example component

- Add **Create Link**  to **ItemList**

- Remove hard coded **PostsListEntry** and **postInfo** from **ItemsList**

- Ask the user about **itemCreateEntryFields** when using plop to generate template

- Modify eslint rules to allow  writing strings in **Link component** like **< link to="posts/create" />**

what's **remaining** : 

- Allow nested inputs names in [Relay Form Fields](https://github.com/Te7a-Houdini/bractal/blob/1b404ac9e77ea3b654ca7bb83a624868c2bbc8d8/plop/templates/module_generator_master_details/sampleModule/containers/ItemCreatePage.js.hbr#L22) as [current implementation in TcombHelpers.js](https://github.com/BadrIT/bractal/blob/develop/src/modules/coreUI/components/forms/TcombHelpers.js#L126) doesn't allow to return a **nested objects** for example 

in **createPost mutation** the object that needs to be send for GraphQl Server must be like this

```js
data:{
     title: "Nice Article33 !" 
     description: "And thi44s is it's description"
     author: {
       connect: {
         id: "cjljjqw1e3i3c0b66w5vphamg"
       }
     }
   }
```
and current **RelayFormFields** only allow one level of input naming [like in sample](https://github.com/BadrIT/bractal/blob/master/docs/assets/relay_form/sample.relayForm.js#L123)

- Implementation of **onSucess** method

- Update the Project **ReadMe** with the new **ItemCreatePage** section
